### PR TITLE
adding more checks inside each instance_group

### DIFF
--- a/src/github.com/cppforlife/bosh-lint/manifest/config.go
+++ b/src/github.com/cppforlife/bosh-lint/manifest/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	IGName       check.Config `yaml:"instance_group_name"`
 	IGAZs        check.Config `yaml:"instance_group_azs"`
+	IGStemcell   check.Config `yaml:"instance_group_stemcell"`
 	IGProperties check.Config `yaml:"instance_group_properties"`
 	IGLinks      check.Config `yaml:"instance_group_links"`
 	StaticIPs    check.Config `yaml:"static_ips"`

--- a/src/github.com/cppforlife/bosh-lint/manifest/ig_stemcell.go
+++ b/src/github.com/cppforlife/bosh-lint/manifest/ig_stemcell.go
@@ -1,0 +1,37 @@
+package manifest
+
+import (
+	check "github.com/cppforlife/bosh-lint/check"
+)
+
+type IGStemcell struct {
+	context  check.Context
+	stemcell interface{}
+	check.Config
+}
+
+func NewIGStemcell(context check.Context, stemcell interface{}, config check.Config) IGStemcell {
+	return IGStemcell{context, stemcell, config}
+}
+
+func (c IGStemcell) Description() check.Description {
+	return check.Description{
+		Context_:   c.context,
+		Purpose_:   "if instance group stemcell is not present",
+		Reasoning_: "It's mandatory to specify stemcell under a instance group.",
+	}
+}
+
+func (c IGStemcell) Check() ([]check.Suggestion, error) {
+	var sugs []check.Suggestion
+
+	if c.stemcell == nil {
+		sugs = append(sugs, check.Simple{
+			Context_:    c.context,
+			Problem_:    "Instance group stemcell is not specified",
+			Resolution_: "Add instance group stemcell",
+		})
+	}
+
+	return sugs, nil
+}

--- a/src/github.com/cppforlife/bosh-lint/manifest/manifest.go
+++ b/src/github.com/cppforlife/bosh-lint/manifest/manifest.go
@@ -74,6 +74,7 @@ func (m LintableManifest) collectChecks() []check.Check {
 
 		checks = append(checks, check.NewDashedName(ctx, ig.Name, m.config.IGName))
 		checks = append(checks, NewIGAZs(ctx, ig.AZs, m.config.IGAZs))
+		checks = append(checks, NewIGStemcell(ctx, ig.Stemcell, m.config.IGStemcell))
 		checks = append(checks, NewIGProperties(ctx, ig.Properties, m.config.IGProperties))
 		checks = append(checks, NewIGLinks(ctx, ig.Consumes, ig.Provides, m.config.IGLinks))
 		checks = append(checks, NewStaticIPs(ctx, ig.Networks, m.config.StaticIPs))

--- a/src/github.com/cppforlife/bosh-lint/manifest/schema.go
+++ b/src/github.com/cppforlife/bosh-lint/manifest/schema.go
@@ -24,6 +24,7 @@ type InstanceGroup struct {
 	Name string
 	AZs  *[]string
 
+	Stemcell   interface{}
 	Properties interface{}
 
 	Consumes interface{}


### PR DESCRIPTION
Hi @cppforlife ,

I just found this tool, and I think its missing some extra checks inside the `instance_groups` . Like the presence of `stemcell`.

This will be useful when adopting `cloud-config`, because some `keys` are moved from `vm_types` to  `instance_groups.

I think this is related to https://github.com/cppforlife/bosh-lint/issues/12
If this is merged, I´m planning to add the checks for `vm_type` and `networks` inside the instance groups.

Regards,
Enrique Encalada